### PR TITLE
Remove the `latest` Branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,8 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['*', '!latest']
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   test:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
This pull request removed the `latest` branch by removing that branch from affecting triggers in the CI workflow.