### PR TITLE
Bump Minimum CMake Version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(
   CheckWarning


### PR DESCRIPTION
This pull request simply bumps the minimum CMake version to 3.5 because compatibility with CMake < 3.5 will be removed from a future version of CMake.