### PR TITLE
Add Support for Installing Module File

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  build:
+    name: Build Project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Configure Project
+        uses: threeal/cmake-action@v1.3.0
+
+      - name: Install Project
+        run: cmake --install build --prefix install
+
+      - name: Upload Project as Artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          path: install

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !.git*
 
 build
+install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,3 +12,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
 endif()
+
+install(
+  FILES cmake/CheckWarning.cmake
+  DESTINATION lib/cmake
+)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![version](https://img.shields.io/github/v/release/threeal/CheckWarning.cmake?style=flat-square)](https://github.com/threeal/CheckWarning.cmake/releases)
 [![license](https://img.shields.io/github/license/threeal/CheckWarning.cmake?style=flat-square)](./LICENSE)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/CheckWarning.cmake/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/CheckWarning.cmake/actions/workflows/build.yaml)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/CheckWarning.cmake/test.yaml?branch=main&style=flat-square)](https://github.com/threeal/CheckWarning.cmake/actions/workflows/test.yaml)
 
 CheckWarning.cmake is a [CMake](https://cmake.org) module that provides utility functions for checking compiler warnings during your project's build process. This module contains a `target_check_warning` function that helps in checking all recommended warnings on a given target.


### PR DESCRIPTION
This pull request introduces the following changes:
- Add support for installing `CheckWarning.cmake` module file to `install/lib/cmake` directory.
- Add `build.yaml` workflow that responsible for building this project and installing the module files on the workflow.

It closes #38.