### PR TITLE
Fix `WARNING_FLAGS` Variable

### DIFF
--- a/cmake/CheckWarning.cmake
+++ b/cmake/CheckWarning.cmake
@@ -1,9 +1,13 @@
-# Set warning flags based on the compiler type.
-if(MSVC)
-  set(WARNING_FLAGS /WX /permissive- /W4 /EHsc)
-else()
-  set(WARNING_FLAGS -Werror -Wall -Wextra -Wpedantic)
-endif()
+# Function to get warning flags based on the compiler type.
+# Arguments:
+#   - VAR: The variable for which to store the warning flags.
+function(_get_warning_flags VAR)
+  if(MSVC)
+    set(${VAR} /WX /permissive- /W4 /EHsc PARENT_SCOPE)
+  else()
+    set(${VAR} -Werror -Wall -Wextra -Wpedantic PARENT_SCOPE)
+  endif()
+endfunction()
 
 # Function to enable warning checks on a specific target.
 # Arguments:
@@ -18,10 +22,12 @@ function(target_check_warning TARGET)
   endif()
 
   # Append warning flags to the compile options.
-  target_compile_options(${TARGET} ${TYPE} ${WARNING_FLAGS})
+  _get_warning_flags(FLAGS)
+  target_compile_options(${TARGET} ${TYPE} ${FLAGS})
 endfunction()
 
 # Function to globally enable warning checks for all targets in the directory.
 function(add_check_warning)
-  add_compile_options(${WARNING_FLAGS})
+  _get_warning_flags(FLAGS)
+  add_compile_options(${FLAGS})
 endfunction()


### PR DESCRIPTION
This pull request fixes #49 by replacing the `WARNING_FLAGS` variable with a `_get_warning_flags` internal function.