### PR TITLE
Disable Install on Subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,21 +17,23 @@ if(SUBPROJECT)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
 endif()
 
-if(NOT SUBPROJECT AND BUILD_TESTING)
-  enable_testing()
-  include(test/CheckWarningTest.cmake)
+if(NOT SUBPROJECT)
+  if(BUILD_TESTING)
+    enable_testing()
+    include(test/CheckWarningTest.cmake)
+  endif()
+
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+    CheckWarningConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion
+  )
+
+  install(
+    FILES
+      cmake/CheckWarning.cmake
+      cmake/CheckWarningConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/CheckWarningConfigVersion.cmake
+    DESTINATION lib/cmake/CheckWarning
+  )
 endif()
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-  CheckWarningConfigVersion.cmake
-  COMPATIBILITY SameMajorVersion
-)
-
-install(
-  FILES
-    cmake/CheckWarning.cmake
-    cmake/CheckWarningConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/CheckWarningConfigVersion.cmake
-  DESTINATION lib/cmake/CheckWarning
-)


### PR DESCRIPTION
This pull request resolves #60 by enabling the installation target only if the project is not included as a subproject. 