### PR TITLE
Add License Notice to Exported Files

### DIFF
--- a/cmake/CheckWarning.cmake
+++ b/cmake/CheckWarning.cmake
@@ -1,3 +1,6 @@
+# This code is licensed under the terms of the MIT License.
+# Copyright (c) 2023-2024 Alfi Maulana
+
 include_guard(GLOBAL)
 
 # Function to get warning flags based on the compiler type.


### PR DESCRIPTION
This pull request resolves #72 by adding a license notice on top of the `cmake/CheckWarning.cmake` file.