### PR TITLE
Utilize CTest Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,4 +22,6 @@ jobs:
           options: BUILD_TESTING=ON
 
       - name: Test Project
-        run: ctest -C debug --output-on-failure --test-dir build --no-tests=error
+        uses: threeal/ctest-action@v1.0.0
+        with:
+          build-config: debug


### PR DESCRIPTION
This pull request resolves #84 by using the [CTest Action](https://github.com/marketplace/actions/ctest-action) as a replacement for the `ctest` command to run tests for this project in the GitHub Actions workflows.