### PR TITLE
Specify CMake Minimum Version in Test Modules

### DIFF
--- a/test/CheckWarningTest.cmake
+++ b/test/CheckWarningTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 function(reconfigure_sample)
   cmake_parse_arguments(ARG "USE_GLOBAL;WITH_UNUSED;IGNORE_UNUSED" "" "" ${ARGN})
   message(STATUS "Reconfiguring sample project")


### PR DESCRIPTION
This pull request resolves #100 by simply specifying the CMake minimum required version in the test modules.