### PR TITLE
Improve Function Arguments Handling

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/CheckWarningTest.cmake
+++ b/test/CheckWarningTest.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 function(reconfigure_sample)
-  cmake_parse_arguments(ARG "USE_GLOBAL;WITH_UNUSED;IGNORE_UNUSED" "" "" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "USE_GLOBAL;WITH_UNUSED;IGNORE_UNUSED" "" "")
   message(STATUS "Reconfiguring sample project")
   if(ARG_USE_GLOBAL)
     list(APPEND CONFIGURE_ARGS -D USE_GLOBAL=TRUE)
@@ -27,7 +27,7 @@ function(reconfigure_sample)
 endfunction()
 
 function(build_sample)
-  cmake_parse_arguments(ARG SHOULD_FAIL "" "" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG SHOULD_FAIL "" "")
   message(STATUS "Building sample project")
   execute_process(
     COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/sample/build


### PR DESCRIPTION
This pull request resolves #103 by introducing the following changes:
- Utilizes the `ARGC` and `ARGV<INDEX>` variables in the `add_cmake_test` function.
- Utilizes the `PARSE_ARGV` version of the `cmake_parse_arguments` function, replacing the standard usage which utilized `ARGN`.