### PR TITLE
Bump Assertion.cmake to Version 0.3.0

### DIFF
--- a/test/CheckWarningTest.cmake
+++ b/test/CheckWarningTest.cmake
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac)
+  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 function(reconfigure_sample)
@@ -19,7 +19,7 @@ function(reconfigure_sample)
     list(APPEND CONFIGURE_ARGS -D IGNORE_UNUSED=TRUE)
   endif()
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}"
+    "${CMAKE_COMMAND}"
       -B ${CMAKE_CURRENT_LIST_DIR}/sample/build
       -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
       ${CONFIGURE_ARGS}
@@ -35,7 +35,7 @@ function(build_sample)
       ERROR ".*")
   else()
     assert_execute_process(
-      COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/sample/build)
+      "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/sample/build)
   endif()
 endfunction()
 


### PR DESCRIPTION
This pull request simply bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [0.3.0](https://github.com/threeal/assertion-cmake/releases/tag/v0.3.0).