### PR TITLE
Fix Sample C Source File Warning Error

### DIFF
--- a/test/sample/src/main.c
+++ b/test/sample/src/main.c
@@ -1,6 +1,6 @@
 #include <success.h>
 
-int main() {
+int main(void) {
 #ifdef WITH_UNUSED
   int unused;
 #endif


### PR DESCRIPTION
This pull request resolves #121 by adding a missing `void` parameter to the `main` function in the sample `main.c` file.