### PR TITLE
Specify Upload Artifact Options in Build Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,4 +23,7 @@ jobs:
       - name: Upload Project as Artifact
         uses: actions/upload-artifact@v4.4.0
         with:
+          name: CheckWarning
           path: install
+          if-no-files-found: error
+          overwrite: true


### PR DESCRIPTION
This pull request resolves #131 by specifying the options for the Upload Artifact action used in the Build workflow as follows:
- Set the `name` input to the project name (`CheckWarning`).
- Set the `if-no-files-found` input to `error`.
- Set the `overwrite` input to `true`.