### PR TITLE
Remove Include Guard in Module

### DIFF
--- a/cmake/CheckWarning.cmake
+++ b/cmake/CheckWarning.cmake
@@ -1,8 +1,6 @@
 # This code is licensed under the terms of the MIT License.
 # Copyright (c) 2023-2024 Alfi Maulana
 
-include_guard(GLOBAL)
-
 # Function to get warning flags based on the compiler type.
 # Arguments:
 #   - VAR: The variable for which to store the warning flags.


### PR DESCRIPTION
This pull request resolves #135 by removing the call to `include_guard` in the `CheckWarning.cmake` module, allowing the module to be included multiple times.