### PR TITLE
Flexible Dependencies Download

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,9 @@ project(
 )
 
 option(CHECK_WARNING_ENABLE_TESTS "Enable test targets.")
-option(CHECK_WARNING_ENABLE_INSTALL "Enable install targets."
-  "${PROJECT_IS_TOP_LEVEL}")
+option(CHECK_WARNING_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(cmake/CheckWarning.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,7 @@ include(cmake/CheckWarning.cmake)
 if(CHECK_WARNING_ENABLE_TESTS)
   enable_testing()
 
-  file(
-    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
-      ${CMAKE_BINARY_DIR}/Assertion.cmake
-    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
-  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
-
+  find_package(Assertion 1.0.0 REQUIRED)
   assertion_add_test(test/check_warning.cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ option(CHECK_WARNING_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+# Prefer system packages over the find modules provided by this project.
+if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+endif()
+
 include(cmake/CheckWarning.cmake)
 
 if(CHECK_WARNING_ENABLE_TESTS)

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,0 +1,8 @@
+file(
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
+    ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Assertion REQUIRED_VARS ASSERTION_LIST_FILE)


### PR DESCRIPTION
This pull request resolves #137 by modifying the dependencies of the project (the [Assertion.cmake](https://github.com/threeal/assertion-cmake/tree/v1.0.0) module) to be downloaded flexibly. This is achieved by adding a new `FindAssertion.cmake` module, which serves as a fallback to download and include the `Assertion.cmake` module if it is not available on the system.

It also modifies the project by appending the `cmake` directory to the [`CMAKE_MODULE_PATH`](https://cmake.org/cmake/help/v3.21/variable/CMAKE_MODULE_PATH.html) variable and enabling the [`CMAKE_FIND_PACKAGE_PREFER_CONFIG`](https://cmake.org/cmake/help/v3.21/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html) variable.