### PR TITLE
Export Get Warning Flags Function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if(CHECK_WARNING_ENABLE_TESTS)
 
   find_package(Assertion 1.0.0 REQUIRED)
   assertion_add_test(test/test_add_check_warning.cmake)
+  assertion_add_test(test/test_get_warning_flags.cmake)
   assertion_add_test(test/test_target_check_warning.cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
   CheckWarning
-  VERSION 2.1.1
+  VERSION 2.2.0
   DESCRIPTION "Check for compiler warnings in your CMake project"
   HOMEPAGE_URL https://github.com/threeal/CheckWarning.cmake
   LANGUAGES NONE)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ include(CheckWarning)
 Alternatively, you can use [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to seamlessly integrate this module into your project.
 
 ```cmake
-cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.1)
+cpmaddpackage(gh:threeal/CheckWarning.cmake@2.2.0)
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ add_library(lib lib.cpp)
 add_executable(main main.cpp)
 ```
 
+### Get Warning Flags
+
+To retrieve the warning flags without adding them to a target, use the `get_warning_flags` function.
+
+```cmake
+get_warning_flags(FLAGS)
+message("Warning flags: ${FLAGS}")
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/cmake/CheckWarning.cmake
+++ b/cmake/CheckWarning.cmake
@@ -23,7 +23,7 @@
 # Function to get warning flags based on the compiler type.
 # Arguments:
 #   - VAR: The variable for which to store the warning flags.
-function(_get_warning_flags VAR)
+function(get_warning_flags VAR)
   if(MSVC)
     set("${VAR}" /WX /permissive- /W4 /EHsc PARENT_SCOPE)
   else()
@@ -44,12 +44,12 @@ function(target_check_warning TARGET)
   endif()
 
   # Append warning flags to the compile options.
-  _get_warning_flags(FLAGS)
+  get_warning_flags(FLAGS)
   target_compile_options("${TARGET}" "${TYPE}" ${FLAGS})
 endfunction()
 
 # Function to globally enable warning checks for all targets in the directory.
 function(add_check_warning)
-  _get_warning_flags(FLAGS)
+  get_warning_flags(FLAGS)
   add_compile_options(${FLAGS})
 endfunction()

--- a/test/test_get_warning_flags.cmake
+++ b/test/test_get_warning_flags.cmake
@@ -1,0 +1,15 @@
+include("${CMAKE_CURRENT_LIST_DIR}/../cmake/CheckWarning.cmake")
+
+section("it should get warning flags for MSVC")
+  set(MSVC TRUE)
+
+  get_warning_flags(FLAGS)
+  assert("${FLAGS}" STREQUAL "/WX;/permissive-;/W4;/EHsc")
+endsection()
+
+section("it should get warning flags for other compilers")
+  unset(MSVC)
+
+  get_warning_flags(FLAGS)
+  assert("${FLAGS}" STREQUAL "-Werror;-Wall;-Wextra;-Wpedantic")
+endsection()


### PR DESCRIPTION
This pull request resolves #143 by renaming the `_get_warning_flags` function to `get_warning_flags`, effectively making it public. It also adds a new test for the function, updates the usage guide in the `README.md` file, and bumps the project version to 2.2.0.