### PR TITLE
Add Module Version Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ message("Warning flags: ${FLAGS}")
 
 ## API Reference
 
+### `CHECK_WARNING_VERSION`
+
+This variable contains the version of the included [`CheckWarning.cmake`](./cmake/CheckWarning.cmake) module.
+
 ### `get_warning_flags`
 
 Retrieves warning flags based on the current compiler.

--- a/cmake/CheckWarning.cmake
+++ b/cmake/CheckWarning.cmake
@@ -20,6 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# This variable contains the version of the included `CheckWarning.cmake` module.
+set(CHECK_WARNING_VERSION 2.2.0)
+
 # Retrieves warning flags based on the current compiler.
 #
 # get_warning_flags(<output_var>)


### PR DESCRIPTION
This pull request resolves #149 by adding a new `CHECK_WARNING_VERSION` variable that contains the version of the included `CheckWarning.cmake` module. It also updates the API reference accordingly.