### PR TITLE
Add CMake Preset for Development

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Configure Project
-        uses: threeal/cmake-action@v2.0.0
-        with:
-          run-build: false
+        run: cmake --preset default
 
       - name: Install Project
         run: cmake --install build --prefix install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,14 +27,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Configure Project
-        uses: threeal/cmake-action@v2.0.0
-        with:
-          generator: Unix Makefiles
-          cxx-compiler: ${{ matrix.compiler }}
-          options: CHECK_WARNING_ENABLE_TESTS=ON
-          run-build: false
+        run: cmake -G 'Unix Makefiles' -D CMAKE_CXX_COMPILER=${{ matrix.compiler }} --preset development
 
       - name: Test Project
-        uses: threeal/ctest-action@v1.1.0
-        with:
-          verbose: true
+        run: ctest --preset development

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,32 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "development",
+      "inherits": ["default"],
+      "cacheVariables": {
+        "CHECK_WARNING_ENABLE_TESTS": "ON"
+      }
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "development",
+      "configurePreset": "development",
+      "output": {
+        "verbosity": "verbose"
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request resolves #169 by adding a new `CMakePresets.json` file that includes configuration and test presets for development. It also updates the CI workflows to utilize these presets.