### PR TITLE
Bump Assertion.cmake to Version 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,12 @@ include(cmake/CheckWarning.cmake)
 if(CHECK_WARNING_ENABLE_TESTS)
   enable_testing()
 
-  find_package(Assertion 1.0.0 REQUIRED)
-  assertion_add_test(test/test_add_check_warning.cmake)
-  assertion_add_test(test/test_get_warning_flags.cmake)
-  assertion_add_test(test/test_target_check_warning.cmake)
+  find_package(Assertion 2.0.0 REQUIRED)
+  list(APPEND CMAKE_SCRIPT_TEST_DEFINITIONS CMAKE_MODULE_PATH)
+
+  add_cmake_script_test(test/test_add_check_warning.cmake)
+  add_cmake_script_test(test/test_get_warning_flags.cmake)
+  add_cmake_script_test(test/test_target_check_warning.cmake)
 endif()
 
 if(CHECK_WARNING_ENABLE_INSTALL)

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,8 +1,11 @@
 file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v2.0.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
-  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+  EXPECTED_MD5 5ebe475aee6fc5660633152f815ce9f6)
 include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Assertion REQUIRED_VARS ASSERTION_LIST_FILE)
+find_package_handle_standard_args(
+  Assertion REQUIRED_VARS ASSERTION_VERSION VERSION_VAR ASSERTION_VERSION)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/cmake)

--- a/test/project_helper.cmake
+++ b/test/project_helper.cmake
@@ -1,3 +1,5 @@
+include(Assertion RESULT_VARIABLE ASSERTION_LIST_FILE)
+
 # This variable contains the header source files for the sample project's
 # `CMakeLists.txt` file.
 set(PROJECT_CMAKELISTS_HEADER_SRC
@@ -10,8 +12,8 @@ set(PROJECT_CMAKELISTS_HEADER_SRC
   "endif()\n"
   "\n"
   "include(${ASSERTION_LIST_FILE})\n"
-  "\n"
   "include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CheckWarning.cmake)\n"
+  "\n"
   "get_warning_flags(WARNING_FLAGS \${WARNING_OPTIONS})\n")
 
 # Asserts configuring the sample project build.
@@ -40,7 +42,7 @@ endfunction()
 function(assert_build_project)
   cmake_parse_arguments(PARSE_ARGV 0 ARG EXPECT_FAIL "" "")
   if(ARG_EXPECT_FAIL)
-    list(APPEND ARGS ERROR .*)
+    list(APPEND ARGS EXPECT_FAIL)
   endif()
   assert_execute_process("${CMAKE_COMMAND}" --build project/build ${ARGS})
 endfunction()

--- a/test/test_add_check_warning.cmake
+++ b/test/test_add_check_warning.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.21)
+
 file(REMOVE_RECURSE project)
 
 include(${CMAKE_CURRENT_LIST_DIR}/project_helper.cmake)

--- a/test/test_get_warning_flags.cmake
+++ b/test/test_get_warning_flags.cmake
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.21)
+
+include(Assertion)
 include("${CMAKE_CURRENT_LIST_DIR}/../cmake/CheckWarning.cmake")
 
 section("retrieve warning flags for MSVC")
@@ -64,8 +67,6 @@ section("it should fail to retrieve warning flags for unsupported compilers")
   set(CMAKE_CXX_COMPILER_ID unsupported)
   set(CMAKE_CXX_SIMULATE_ID "")
 
-  assert_fatal_error(
-    CALL get_warning_flags FLAGS
-    MESSAGE "CheckWarning: Unsupported compiler for retrieving "
-      "warning flags: unsupported")
+  assert_call(get_warning_flags FLAGS EXPECT_ERROR STREQUAL
+    "CheckWarning: Unsupported compiler for retrieving warning flags: unsupported")
 endsection()

--- a/test/test_target_check_warning.cmake
+++ b/test/test_target_check_warning.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.21)
+
 file(REMOVE_RECURSE project)
 
 include(${CMAKE_CURRENT_LIST_DIR}/project_helper.cmake)


### PR DESCRIPTION
This pull request updates the [Assertion.cmake](https://github.com/threeal/assertion-cmake/) package used by this project to version [2.0.0](https://github.com/threeal/assertion-cmake/releases/tag/v2.0.0).