### PR TITLE
Fix Test Workflow Not Correctly Test Compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,11 @@ if(CHECK_WARNING_ENABLE_TESTS)
   enable_testing()
 
   find_package(Assertion 2.0.0 REQUIRED)
+
   list(APPEND CMAKE_SCRIPT_TEST_DEFINITIONS CMAKE_MODULE_PATH)
+  if(DEFINED CMAKE_CXX_COMPILER)
+   list(APPEND CMAKE_SCRIPT_TEST_DEFINITIONS CMAKE_CXX_COMPILER)
+  endif()
 
   add_cmake_script_test(test/test_add_check_warning.cmake)
   add_cmake_script_test(test/test_get_warning_flags.cmake)

--- a/test/project_helper.cmake
+++ b/test/project_helper.cmake
@@ -26,6 +26,7 @@ set(PROJECT_CMAKELISTS_HEADER_SRC
 function(assert_configure_project)
   cmake_parse_arguments(PARSE_ARGV 0 ARG NO_TREAT_WARNINGS_AS_ERRORS "" "")
   if(DEFINED CMAKE_CXX_COMPILER)
+    message("Compiling with: ${CMAKE_CXX_COMPILER}")
     list(APPEND ARGS -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
   endif()
   if(ARG_NO_TREAT_WARNINGS_AS_ERRORS)

--- a/test/project_helper.cmake
+++ b/test/project_helper.cmake
@@ -25,6 +25,9 @@ set(PROJECT_CMAKELISTS_HEADER_SRC
 # configures the build without treating warnings as errors.
 function(assert_configure_project)
   cmake_parse_arguments(PARSE_ARGV 0 ARG NO_TREAT_WARNINGS_AS_ERRORS "" "")
+  if(DEFINED CMAKE_CXX_COMPILER)
+    list(APPEND ARGS -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+  endif()
   if(ARG_NO_TREAT_WARNINGS_AS_ERRORS)
     list(APPEND ARGS -D TREAT_WARNINGS_AS_ERRORS=OFF)
   endif()


### PR DESCRIPTION
This pull request resolves #174 by fixing the Test workflow, which did not correctly test different compilers, by modifying the test to support specifying the compiler using the `CMAKE_CXX_COMPILER` variable.