### PR TITLE
Follow CMake Starter Version 2.2.0 Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
   CheckWarning
-  VERSION 3.1.0
+  VERSION 3.2.0
   DESCRIPTION "Check for compiler warnings in CMake projects"
   HOMEPAGE_URL https://github.com/threeal/CheckWarning.cmake
   LANGUAGES NONE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,14 @@ project(
 option(CHECK_WARNING_ENABLE_TESTS "Enable test targets.")
 option(CHECK_WARNING_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Prefer system packages over the find modules provided by this project.
 if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
   set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 endif()
 
-include(cmake/CheckWarning.cmake)
+include(CheckWarning)
 
 if(CHECK_WARNING_ENABLE_TESTS)
   enable_testing()
@@ -36,7 +36,8 @@ endif()
 
 if(CHECK_WARNING_ENABLE_INSTALL)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/CheckWarningConfig.cmake
-    "include(\${CMAKE_CURRENT_LIST_DIR}/CheckWarning.cmake)\n")
+    "list(PREPEND CMAKE_MODULE_PATH \${CMAKE_CURRENT_LIST_DIR})\n"
+    "include(CheckWarning)\n")
 
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(cmake/CheckWarningConfigVersion.cmake

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The recommended way to integrate this module into a project is by downloading it
 
 ```cmake
 file(
-  DOWNLOAD https://github.com/threeal/CheckWarning.cmake/releases/download/v3.1.0/CheckWarning.cmake
+  DOWNLOAD https://github.com/threeal/CheckWarning.cmake/releases/download/v3.2.0/CheckWarning.cmake
     ${CMAKE_BINARY_DIR}/cmake/CheckWarning.cmake
-  EXPECTED_MD5 0bebb9832bfce552de734d1b24e0287c)
+  EXPECTED_MD5 8f9c3170e816ba99a3ddc6848a8456f0)
 
 include(${CMAKE_BINARY_DIR}/cmake/CheckWarning.cmake)
 ```

--- a/cmake/CheckWarning.cmake
+++ b/cmake/CheckWarning.cmake
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # This variable contains the version of the included `CheckWarning.cmake` module.
-set(CHECK_WARNING_VERSION 3.1.0)
+set(CHECK_WARNING_VERSION 3.2.0)
 
 # Retrieves warning flags based on the current compiler.
 #

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,11 +1,9 @@
-file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v2.0.0/Assertion.cmake
-    ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
-  EXPECTED_MD5 5ebe475aee6fc5660633152f815ce9f6)
-include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
+set(DOWNLOAD_URL https://github.com/threeal/assertion-cmake/releases/download)
+file(DOWNLOAD ${DOWNLOAD_URL}/v${Assertion_FIND_VERSION}/Assertion.tar.gz
+  ${CMAKE_BINARY_DIR}/_deps/Assertion.tar.gz)
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  Assertion REQUIRED_VARS ASSERTION_VERSION VERSION_VAR ASSERTION_VERSION)
+file(ARCHIVE_EXTRACT INPUT ${CMAKE_BINARY_DIR}/_deps/Assertion.tar.gz
+  DESTINATION ${CMAKE_BINARY_DIR}/_deps)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/cmake)
+include(CMakeFindDependencyMacro)
+find_dependency(Assertion CONFIG PATHS ${CMAKE_BINARY_DIR}/_deps)

--- a/test/project_helper.cmake
+++ b/test/project_helper.cmake
@@ -1,4 +1,5 @@
 include(Assertion RESULT_VARIABLE ASSERTION_LIST_FILE)
+include(CheckWarning RESULT_VARIABLE CHECK_WARNING_LIST_FILE)
 
 # This variable contains the header source files for the sample project's
 # `CMakeLists.txt` file.
@@ -12,7 +13,7 @@ set(PROJECT_CMAKELISTS_HEADER_SRC
   "endif()\n"
   "\n"
   "include(${ASSERTION_LIST_FILE})\n"
-  "include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CheckWarning.cmake)\n"
+  "include(${CHECK_WARNING_LIST_FILE})\n"
   "\n"
   "get_warning_flags(WARNING_FLAGS \${WARNING_OPTIONS})\n")
 

--- a/test/test_get_warning_flags.cmake
+++ b/test/test_get_warning_flags.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 include(Assertion)
-include("${CMAKE_CURRENT_LIST_DIR}/../cmake/CheckWarning.cmake")
+include(CheckWarning)
 
 section("retrieve warning flags for MSVC")
   set(CMAKE_CXX_COMPILER_ID MSVC)


### PR DESCRIPTION
This pull request resolves #180 by following the CMake Starter version 2.2.0 configuration as follows:
- Prepends the `CMAKE_MODULE_PATH` variable with the path of the main module directory.
- Modifies the `FindAssertion.cmake` module to download the `Assertion.tar.gz` file to fulfill the Assertion package find.
- Bumps the project to version 3.2.0, preparing it for the upcoming release.